### PR TITLE
Add New Zealand bands & allowed consumer range.

### DIFF
--- a/frequency_data/country_bands/NZ/UNLICENSED_BANDS_NZ.json
+++ b/frequency_data/country_bands/NZ/UNLICENSED_BANDS_NZ.json
@@ -1,5 +1,5 @@
 { "label":"NZ - Unlicensed bands", "submenu": [
     { "label": "Radio Microphone Devices GUSL Band 1 (502 - 606MHz)"    , "start_freq": 502000 , "stop_freq": 606000 , "details": "Radio Microphone Devices GUSL Band 1 (502 - 606MHz)"       },
     { "label": "Radio Microphone Devices GUSL Band 2 (622 - 698MHz)"    , "start_freq": 622000 , "stop_freq": 698000 , "details": "Radio Microphone Devices GUSL Band 1 (622 - 698MHz)"       },
-    { "label": "Radio Microphone Devices GUSL (502 - 698MHz)"    , "start_freq": 502000 , "stop_freq": 698000 , "details": "Radio Microphone Devices GUSL(502 - 698MHz)"       },
+    { "label": "Radio Microphone Devices GUSL (502 - 698MHz)"    , "start_freq": 502000 , "stop_freq": 698000 , "details": "Radio Microphone Devices GUSL(502 - 698MHz)"       }
 ]}

--- a/frequency_data/country_bands/NZ/UNLICENSED_BANDS_NZ.json
+++ b/frequency_data/country_bands/NZ/UNLICENSED_BANDS_NZ.json
@@ -1,0 +1,5 @@
+{ "label":"NZ - Unlicensed bands", "submenu": [
+    { "label": "Radio Microphone Devices GUSL Band 1 (502 - 606MHz)"    , "start_freq": 502000 , "stop_freq": 606000 , "details": "Radio Microphone Devices GUSL Band 1 (502 - 606MHz)"       },
+    { "label": "Radio Microphone Devices GUSL Band 2 (622 - 698MHz)"    , "start_freq": 622000 , "stop_freq": 698000 , "details": "Radio Microphone Devices GUSL Band 1 (622 - 698MHz)"       },
+    { "label": "Radio Microphone Devices GUSL (502 - 698MHz)"    , "start_freq": 502000 , "stop_freq": 698000 , "details": "Radio Microphone Devices GUSL(502 - 698MHz)"       },
+]}

--- a/frequency_data/forbidden/FORBIDDEN_nz.json
+++ b/frequency_data/forbidden/FORBIDDEN_nz.json
@@ -1,0 +1,5 @@
+[
+    { "start": 0  , "stop": 502000  , "info": "Forbidden" },
+    { "start": 606000 , "stop": 622000  , "info": "Māori reserved sound broadcasting licence" },
+    { "start": 698000 , "stop": 2400000 , "info": "Forbidden" },
+]

--- a/frequency_data/forbidden/FORBIDDEN_nz.json
+++ b/frequency_data/forbidden/FORBIDDEN_nz.json
@@ -1,5 +1,5 @@
 [
     { "start": 0  , "stop": 502000  , "info": "Forbidden" },
-    { "start": 606000 , "stop": 622000  , "info": "Māori reserved sound broadcasting licence" },
-    { "start": 698000 , "stop": 2400000 , "info": "Forbidden" },
+    { "start": 606000 , "stop": 622000  , "info": "Māori reserved" },
+    { "start": 698000 , "stop": 2400000 , "info": "Forbidden" }
 ]


### PR DESCRIPTION
General User Spectrum License:
https://www.rsm.govt.nz/licensing/frequencies-for-anyone/radio-microphone-devices-gusl

606-622 are reserved for Maori licensing, which can be applied for.
May look at adding licensable information to the app. Cause it's licensable rather than forbidden. :shrug: